### PR TITLE
Add repository property

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,10 @@
     "dist",
     "README.md"
   ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/rollup/rollup-plugin-json.git"
+  },
   "dependencies": {
     "rollup-pluginutils": "^1.5.2"
   }


### PR DESCRIPTION
This eliminates an npm warning, and also lets tools like greenkeeper and npmjs provide links back to the github repository.
