### PR TITLE
add license to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "dist",
     "README.md"
   ],
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/rollup/rollup-plugin-json.git"


### PR DESCRIPTION
Because tools like npm, libraries.io, and dependencyci.com
expect that to be where the license is declared.

Also, it's breaking my dependencyci [build](https://dependencyci.com/github/paypal/glamorous/builds/33) :-(