### PR TITLE
Add namedExports: true/false option

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,11 @@ export default {
       include: 'node_modules/**',
       exclude: [ 'node_modules/foo/**', 'node_modules/bar/**' ],
       
-      // for tree-shaking, properties will be declared as
-      // variables, using either `var` or `const`
+      // for tree-shaking, properties with valid keys will be
+      // declared as variables with export
+      namedExports: true, // Default: true
+
+      // declare variables using either `var` or `const`
       preferConst: true, // Default: false
 
       // specify indentation for the generated default export —

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,8 @@ import { createFilter, makeLegalIdentifier } from 'rollup-pluginutils';
 export default function json(options = {}) {
 	const filter = createFilter(options.include, options.exclude);
 
+	const namedExports = options.namedExports !== false;
+
 	return {
 		name: 'json',
 
@@ -21,7 +23,7 @@ export default function json(options = {}) {
 				body: []
 			};
 
-			if (Object.prototype.toString.call(data) !== '[object Object]') {
+			if (!namedExports || Object.prototype.toString.call(data) !== '[object Object]') {
 				code = `export default ${json};`;
 
 				ast.body.push({


### PR DESCRIPTION
This PR allows named exports for properties with valid keys to be turned off.

Consider a case where a JSON object contains lots of static data. All the data are necessary, and the whole JSON file is being imported as default. And because all the properties are accessed dynamically by their keys, it is not possible to statically import each property to take advantage of tree-shaking.

I have a case where half of the properties have valid keys and the rest of them do not (they contain dashes). The current output looks ugly - with half of properties declared as variable on top, followed by a object declaration that maps the first half into the object, then followed by the rest half of the properties whose keys contain dashes - and the output is slightly larger than importing JSON object as is after `uglify()`.

Rollup's tree-shaking works very well in most of cases for me, but not in this one. Therefore, I would like to propose this new option that allows turning off variable declarations.