### PR TITLE
updates README example with updated options names

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,11 @@ npm install --save-dev rollup-plugin-json
 import json from 'rollup-plugin-json';
 
 export default {
-  entry: 'src/main.js',
-  dest: 'dist/bundle.js',
-  format: 'iife',
+  input: 'src/main.js',
+  output: {
+    file: 'dist/bundle.js'
+    format: 'iife',
+  },
 
   plugins: [
     json({
@@ -38,7 +40,7 @@ export default {
       // but you can also specifically include/exclude files
       include: 'node_modules/**',
       exclude: [ 'node_modules/foo/**', 'node_modules/bar/**' ],
-      
+
       // for tree-shaking, properties will be declared as
       // variables, using either `var` or `const`
       preferConst: true, // Default: false


### PR DESCRIPTION
if the example in the README is used, Rollup 0.48 and up will give

```
(!) Some options have been renamed
https://gist.github.com/Rich-Harris/d472c50732dab03efeb37472b08a3f32
entry is now input
dest is now output.file
format is now output.format
```

see https://gist.github.com/Rich-Harris/d472c50732dab03efeb37472b08a3f32

this PR updates the example as suggested by the CLI.