### PR TITLE
Expose the "compact" and "namedExports" options

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,10 @@ export default {
       indent: '  ',
 
       // ignores indent and generates the smallest code
-      compact: true // Default: false
+      compact: true, // Default: false
+
+      // generate a named export for every property of the JSON object
+      namedExports: true // Default: true
     })
   ]
 };

--- a/README.md
+++ b/README.md
@@ -47,7 +47,10 @@ export default {
 
       // specify indentation for the generated default export —
       // defaults to '\t'
-      indent: '  '
+      indent: '  ',
+
+      // ignores indent and generates the smallest code
+      compact: true // Default: false
     })
   ]
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -4004,9 +4004,9 @@
       }
     },
     "rollup-pluginutils": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.2.0.tgz",
-      "integrity": "sha512-aqjTUCfZJK3O+TjH++PdQc8Lg6V6t/1Fhu8/6f3qPQzBt0xZruDgqblvb3RQOfKybTgfxKpyy2pQmQ4X2OmY4w==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.3.0.tgz",
+      "integrity": "sha512-xB6hsRsjdJdIYWEyYUJy/3ki5g69wrf0luHPGNK3ZSocV6HLNfio59l3dZ3TL4xUwEKgROhFi9jOCt6c5gfUWw==",
       "requires": {
         "estree-walker": "^0.5.2",
         "micromatch": "^2.3.11"

--- a/package.json
+++ b/package.json
@@ -34,6 +34,6 @@
   "license": "MIT",
   "repository": "rollup/rollup-plugin-json",
   "dependencies": {
-    "rollup-pluginutils": "^2.2.0"
+    "rollup-pluginutils": "^2.3.0"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -20,6 +20,7 @@ export default function json (options = {}) {
 				code: dataToEsm(data, {
 					preferConst: options.preferConst,
 					compact: options.compact,
+					namedExports: options.namedExports,
 					indent
 				}),
 				map: {mappings: ''}

--- a/src/index.js
+++ b/src/index.js
@@ -17,7 +17,11 @@ export default function json (options = {}) {
 			}
 
 			return {
-				code: dataToEsm(data, {preferConst: options.preferConst, indent}),
+				code: dataToEsm(data, {
+					preferConst: options.preferConst,
+					compact: options.compact,
+					indent
+				}),
 				map: {mappings: ''}
 			};
 		}

--- a/test/samples/form/compact.js
+++ b/test/samples/form/compact.js
@@ -1,0 +1,1 @@
+export var validKey=true;export var nested={subKey:"ok"};export var array=[1,"2"];export default{validKey:validKey,"invalid-key": 1,nested:nested,array:array,"function": "not used","null": null};

--- a/test/samples/form/customIndent.js
+++ b/test/samples/form/customIndent.js
@@ -11,5 +11,6 @@ export default {
   "invalid-key": 1,
   nested: nested,
   array: array,
-  "function": "not used"
+  "function": "not used",
+  "null": null
 };

--- a/test/samples/form/default.js
+++ b/test/samples/form/default.js
@@ -11,5 +11,6 @@ export default {
 	"invalid-key": 1,
 	nested: nested,
 	array: array,
-	"function": "not used"
+	"function": "not used",
+	"null": null
 };

--- a/test/samples/form/input.json
+++ b/test/samples/form/input.json
@@ -5,5 +5,6 @@
     "subKey": "ok"
   },
   "array": [1, "2"],
-  "function": "not used"
+  "function": "not used",
+  "null": null
 }

--- a/test/samples/form/namedExports.js
+++ b/test/samples/form/namedExports.js
@@ -1,0 +1,13 @@
+export default {
+	validKey: true,
+	"invalid-key": 1,
+	nested: {
+		subKey: "ok"
+	},
+	array: [
+		1,
+		"2"
+	],
+	"function": "not used",
+	"null": null
+};

--- a/test/samples/form/preferConst.js
+++ b/test/samples/form/preferConst.js
@@ -11,5 +11,6 @@ export default {
 	"invalid-key": 1,
 	nested: nested,
 	array: array,
-	"function": "not used"
+	"function": "not used",
+	"null": null
 };

--- a/test/test.js
+++ b/test/test.js
@@ -138,6 +138,13 @@ describe('rollup-plugin-json', () => {
 			read('samples/form/customIndent.js')
 		);
 	});
+
+	it('generates correct code with compact', () => {
+		assert.deepEqual(
+			json({ compact: true }).transform(read('samples/form/input.json'), 'input.json').code + '\n',
+			read('samples/form/compact.js')
+		);
+	});
 });
 
 function read (file) {

--- a/test/test.js
+++ b/test/test.js
@@ -139,10 +139,17 @@ describe('rollup-plugin-json', () => {
 		);
 	});
 
-	it('generates correct code with compact', () => {
+	it('generates correct code with compact=true', () => {
 		assert.deepEqual(
 			json({ compact: true }).transform(read('samples/form/input.json'), 'input.json').code + '\n',
 			read('samples/form/compact.js')
+		);
+	});
+
+	it('generates correct code with namedExports=false', () => {
+		assert.deepEqual(
+			json({ namedExports: false }).transform(read('samples/form/input.json'), 'input.json').code + '\n',
+			read('samples/form/namedExports.js')
 		);
 	});
 });


### PR DESCRIPTION
It'd be helpful to get a bit more control over the code generated but this plugin. Luckily rollup-pluginutils contains some more useful options, this PR exposes & documents them.

Includes #44 as it's necessary for `namedExports`