### PR TITLE
Add index.d.ts typings file

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,40 @@
+import { Plugin } from 'rollup';
+
+interface RollupJsonOptions {
+	/**
+	 * All JSON files will be parsed by default,
+	 * but you can also specifically include files
+	 */
+	include?: string | RegExp | ReadonlyArray<string | RegExp> | null;
+	/**
+	 * All JSON files will be parsed by default,
+	 * but you can also specifically exclude files
+	 */
+	exclude?: string | RegExp | ReadonlyArray<string | RegExp> | null;
+	/**
+	 * For tree-shaking, properties will be declared as variables, using
+	 * either `var` or `const`.
+	 * @default false
+	 */
+	preferConst?: boolean;
+	/**
+	 * Specify indentation for the generated default export
+	 * @default '\t'
+	 */
+	indent: string;
+	/**
+	 * Ignores indent and generates the smallest code
+	 * @default false
+	 */
+	compact: boolean;
+	/**
+	 * Generate a named export for every property of the JSON object
+	 * @default true
+	 */
+	namedExports: true;
+}
+
+/**
+ * Convert .json files to ES6 modules
+ */
+export default function json(options?: RollupJsonOptions): Plugin;

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "source-map-support": "^0.5.11"
   },
   "scripts": {
-    "test": "mocha",
+    "test": "mocha && tsc",
     "pretest": "npm run build",
     "build": "rollup -c",
     "prebuild": "rm -rf dist/*",
@@ -28,6 +28,7 @@
   "files": [
     "src",
     "dist",
+    "index.d.ts",
     "README.md"
   ],
   "license": "MIT",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,16 @@
+{
+    "compilerOptions": {
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strict": true,
+        "noEmit": true,
+        "allowJs": true
+    },
+    "files": [
+        "index.d.ts",
+        "typings-test.js"
+    ]
+}

--- a/typings-test.js
+++ b/typings-test.js
@@ -1,0 +1,23 @@
+// @ts-check
+import json from '.';
+
+/** @type {import("rollup").RollupOptions} */
+const config = {
+	input: 'main.js',
+	output: {
+		file: 'bundle.js',
+		format: 'iife'
+	},
+	plugins: [
+		json({
+			include: 'node_modules/**',
+			exclude: ['node_modules/foo/**', 'node_modules/bar/**'],
+			preferConst: true,
+			indent: '  ',
+			compact: true,
+			namedExports: true
+		})
+	]
+};
+
+export default config;


### PR DESCRIPTION
My continued efforts to fully support typechecking a Rollup config with TypeScript.

TypeScript allows for checking normal Javascript files by adding a `// @ts-check` comment at the top of the file. By providing typings users can check that they aren't passing misspelled or incorrect parameters, and see a hint about what each option does in their editor.